### PR TITLE
Update and rename __init__.py to __main__.py

### DIFF
--- a/llvd/__main__.py
+++ b/llvd/__main__.py
@@ -59,3 +59,5 @@ def main(cookies, course, resolution, caption):
 
         llvd = App(email, password, course_slug, resolution, caption)
         llvd.run()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixed 'llvd' is not recognized as an internal or external command #42 . Now '$python -m llvd <flags>' works perfectly