### PR TITLE
Chapter and video names are reformatted

### DIFF
--- a/llvd/app.py
+++ b/llvd/app.py
@@ -164,11 +164,15 @@ class App:
             chapters = r.json()['elements'][0]['chapters']
             exercise_files = r.json()["elements"][0]["exerciseFileUrls"]
             chapters_index = 1
-            if len(chapters) > 0 and chapters[0]["title"] == "Introduction":
+            if len(chapters) > 0 and chapters[0]["title"] in ["Introduction", "Welcome"]:
                 chapters_index = 0
             chapters_pad_length = 1
-            if len(chapters) > 9:
-                chapters_pad_length = 2
+            if chapters_index == 0:
+                if len(chapters) - 1 > 9:
+                    chapters_pad_length = 2
+            else:
+                if len(chapters) > 9:
+                    chapters_pad_length = 2
             delay = self.throttle
 
             for chapter in chapters:

--- a/llvd/app.py
+++ b/llvd/app.py
@@ -164,16 +164,22 @@ class App:
             chapters = r.json()['elements'][0]['chapters']
             exercise_files = r.json()["elements"][0]["exerciseFileUrls"]
             chapters_index = 1
+            if len(chapters) > 0 and chapters[0]["title"] == "Introduction":
+                chapters_index = 0
+            chapters_pad_length = 1
+            if len(chapters) > 9:
+                chapters_pad_length = 2
             delay = self.throttle
 
             for chapter in chapters:
                 chapter_name = chapter["title"]
                 videos = chapter["videos"]
-                chapter_path = f'./{self.course_slug}/{chapters_index:0=2d}-{clean_name(chapter_name)}'
+                chapters_index_padded = str(chapters_index).rjust(chapters_pad_length, "0")
+                chapter_path = f'./{self.course_slug}/{chapters_index_padded}. {clean_name(chapter_name)}'
                 course_path = f'./{self.course_slug}'
                 chapters_index += 1
                 video_index = 1
-                self.chapter_path = f'./{self.course_slug}/{chapters_index-1:0=2d}-{clean_name(chapter_name)}'
+                self.chapter_path = f'./{self.course_slug}/{chapters_index_padded}. {clean_name(chapter_name)}'
                 if not os.path.exists(chapter_path):
                     os.makedirs(chapter_path)
                 for video in videos:
@@ -200,13 +206,13 @@ class App:
                                              ['selectedVideo']['durationInSeconds']) * 1000
 
                         click.echo(
-                            click.style(f"\nCurrent: {chapters_index-1:0=2d}-{clean_name(chapter_name)}/"\
-                                f"{video_index:0=2d}-{video_name}.mp4 @{self.video_format}p"))
+                            click.style(f"\nCurrent: {chapters_index_padded}. {clean_name(chapter_name)}/"\
+                                f"{video_index:0=2d}. {video_name}.mp4 @{self.video_format}p"))
                         current_files = []
                         for file in os.listdir(chapter_path):
-                            if file.endswith(".mp4") and "-" in file:
+                            if file.endswith(".mp4") and ". " in file:
                                 ff = re.split(
-                                    "\d+-", file)[1].replace(".mp4", "")
+                                    "\d+\. ", file)[1].replace(".mp4", "")
                                 current_files.append(ff)
                     except Exception as e:
                         if 'url' in str(e):
@@ -238,7 +244,7 @@ class App:
         except KeyError:
                 click.echo(click.style(f"That course is not found", fg="red"))
         except Exception as e:
-            if os.path.exists(f'{self.chapter_path}/{self.current_video_index:0=2d}-{clean_name(self.current_video_name)}.mp4'):
-                os.remove(f'{self.chapter_path}/{self.current_video_index:0=2d}-{clean_name(self.current_video_name)}.mp4')
+            if os.path.exists(f'{self.chapter_path}/{self.current_video_index:0=2d}. {clean_name(self.current_video_name)}.mp4'):
+                os.remove(f'{self.chapter_path}/{self.current_video_index:0=2d}. {clean_name(self.current_video_name)}.mp4')
             traceback.print_exc()    
             self.download_entire_course()

--- a/llvd/app.py
+++ b/llvd/app.py
@@ -95,7 +95,7 @@ class App:
 
 
     @staticmethod
-    def resume_failed_ownloads():
+    def resume_failed_downloads():
         """
             Resume failed downloads
         """
@@ -155,7 +155,7 @@ class App:
         """
             Download a course
         """
-        self.resume_failed_ownloads()
+        self.resume_failed_downloads()
         try:
             r = requests.get(config.course_url.format(
                 self.course_slug), cookies=self.cookies, headers=self.headers)

--- a/llvd/downloader.py
+++ b/llvd/downloader.py
@@ -16,7 +16,7 @@ def download_video(url, index, filename, path, delay=None):
     if delay:
         throttle( delay );
     maximum_retries = 5
-    with open(f'{path}/{index:0=2d}-{clean_name(filename)}.mp4', 'wb') as f:
+    with open(f'{path}/{index:0=2d}. {clean_name(filename)}.mp4', 'wb') as f:
         download_size = 0
         while maximum_retries > 0:
             requests.adapters.HTTPAdapter(max_retries=maximum_retries)
@@ -54,7 +54,7 @@ def download_subtitles(index, subs, video_name, path, video_duration):
             f"{subtitles_time_format(starts_at)} --> {subtitles_time_format(ends_at)}\n" \
             f"{caption}\n\n"
 
-    with open(f"{path}/{index:0=2d}-{clean_name(video_name).strip()}.srt", 'wb') as f:
+    with open(f"{path}/{index:0=2d}. {clean_name(video_name).strip()}.srt", 'wb') as f:
         click.echo(f"Downloading subtitles..")
         for line in starmap(subs_to_lines, enumerate(subs, start=1)):
             f.write(line.encode('utf8'))


### PR DESCRIPTION
* Item names are reformatted to match the course info on the site page.
* Double char padding for the chapter index is only necessary if the chapter count is greater than 9.
* Didn't think that this padding optimization is necessary for the videos as there can easily be more then 9. Maybe, the same thing can be applied (later) to the videos too, for consistency.