### PR TITLE
Fixed NoneObject error caused by having empty lines in the header file

### DIFF
--- a/llvd/process_io.py
+++ b/llvd/process_io.py
@@ -19,16 +19,22 @@ def parse_cookie_file():
             click.style(f"cookies.txt not found or is empty", fg="red"))
         sys.exit(0)
 
-def parse_header_file(path = "headers.txt"):
+def parse_header_file(path="headers.txt"):
     headers = {}
+
     try:
-        with open(path, "r", encoding="utf8") as cookies_file:
-            lines = cookies_file.readlines()
-            for line in lines:
-                parts = line.split("=",1)
-                key, value = parts + [None]*(2-len(parts))
-                headers[key] = value.replace("\"", "").strip()
+        with open(path, "r", encoding="utf8") as file:
+            for line in file:
+                line = line.strip()
+
+                if not line:
+                    continue
+
+                key, value = line.split("=", 1)
+                headers[key] = value.replace('"', "")
+
         return headers
+
     except FileNotFoundError:
         click.echo(
             click.style(f"{path} not found or is empty", fg="red"))


### PR DESCRIPTION
- Added a check to skip empty lines in header file

Fixes #138 