### PR TITLE
fix: Match subtitle file naming format to video files (fixes #137)

### DIFF
--- a/llvd/downloader.py
+++ b/llvd/downloader.py
@@ -70,7 +70,7 @@ def download_video(url, index, filename, path, delay=None, proxies=None):
 
 def download_subtitles(index, subs, video_name, path, video_duration):
     """Write to a file (subtitle file) caption matching the right time."""
-    with open(f"{path}/{index:0=2d}. {clean_name(video_name).strip()}.srt", "wb") as f:
+    with open(f"{path}/{index:02d} {clean_name(video_name).strip()}.srt", "wb") as f:
         click.echo("Downloading subtitles..")
         for i, sub in enumerate(subs, start=1):
             starts_at = sub["transcriptStartAt"]


### PR DESCRIPTION
Fixes #137

## Problem
Subtitle files are named with a period separator (e.g., '01. Introduction.srt') while video files use spaces (e.g., '01 Introduction.mp4'), causing them not to match.

## Solution
Changed subtitle file naming format to use space separator instead of period, making them consistent with video files:
- Before: `01. Introduction.srt` / `01 Introduction.mp4`
- After: `01 Introduction.srt` / `01 Introduction.mp4`

## Benefits
- Subtitle files now match their corresponding video files
- Improved file organization and discoverability
- More intuitive file naming convention